### PR TITLE
[FEAT]: Added split payment type defs

### DIFF
--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -204,6 +204,11 @@ export interface Transaction {
     };
   };
   ref?: string;
+  isPaystack?: boolean;
+  isCheque?: boolean;
+  cheque?: Cheque;
+  isSplitPayment?: boolean;
+  splitPayment?: SplitPayment;
   accessCode?: string;
   receiptUrl?: string;
   approvedBy?: User;
@@ -500,4 +505,47 @@ export interface Notification {
   isRead: boolean;
   isDeleted: boolean;
   createdAt: Date;
+}
+
+type TransactionSplit = {
+  transaction: Transaction;
+  splitType: "fixed" | "percentage";
+  splitAmount?: number;
+  splitPercentage?: number;
+  dueDate: Date;
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+export interface SplitPayment {
+  amount: number;
+  currency: string;
+  transactions: TransactionSplit[];
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface Cheque {
+  number: string;
+  bank: string;
+  accountNumber: string;
+  amount: number;
+  issuedDate: Date;
+  expiryDate: Date;
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type CashDenomination = {
+  denomination: number;
+  quantity: number;
+};
+export interface Cash {
+  amount: number;
+  denominations: CashDenomination[];
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
 }


### PR DESCRIPTION
This pull request expands the payment-related type definitions in `backend/src/types/index.ts` to support additional payment methods and split payment functionality. The most important changes are the introduction of new interfaces for split payments, cheques, and cash, as well as updates to the `Transaction` interface to accommodate these new types.

**Payment Method Extensions:**

* Added new boolean flags (`isPaystack`, `isCheque`, `isSplitPayment`) and corresponding objects (`cheque`, `splitPayment`) to the `Transaction` interface, allowing transactions to specify their payment method and related details.

**New Payment Type Interfaces:**

* Introduced the `Cheque` interface to capture cheque-specific information such as cheque number, bank, account number, amount, issue and expiry dates, and metadata.
* Added the `SplitPayment` interface, which defines the structure for split payments, including amount, currency, and an array of `TransactionSplit` objects detailing how the payment is divided.
* Defined the `TransactionSplit` type to represent individual splits within a split payment, supporting both fixed and percentage splits, and including due dates and metadata.
* Created the `Cash` interface and supporting `CashDenomination` type to represent cash payments with denomination breakdowns and related metadata.