### PR TITLE
Created tax schedule

### DIFF
--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -36,3 +36,4 @@ export { SplitPaymentModel, SplitPaymentDocument } from "./splitPayment.model";
 export { ChequeModel, ChequeDocument } from "./cheque.model";
 export { CashModel, CashDocument } from "./cash.model";
 export { RentalModel, RentalDocument } from "./rental.model";
+export { TaxScheduleModel, TaxScheduleDocument } from "./taxSchedule.model";

--- a/backend/src/models/transaction.model.ts
+++ b/backend/src/models/transaction.model.ts
@@ -53,6 +53,7 @@ const TransactionSchema = new Schema<TransactionDocument>(
     splitPayment: { type: Schema.Types.ObjectId, ref: "SplitPayment" },
     isCash: { type: Boolean },
     cash: { type: Schema.Types.ObjectId, ref: "Cash" },
+    taxes: { type: Schema.Types.ObjectId, ref: "TaxSchedule" },
     accessCode: { type: String },
     receiptUrl: { type: String },
     approvedBy: { type: Schema.Types.ObjectId, ref: "User" },

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -211,6 +211,7 @@ export interface Transaction {
   splitPayment?: SplitPayment;
   isCash?: boolean;
   cash: Cash;
+  taxes: mongoose.Types.ObjectId | string;
   accessCode?: string;
   receiptUrl?: string;
   approvedBy?: User;


### PR DESCRIPTION
This pull request introduces a new `TaxSchedule` model and integrates it into the transaction system. The main focus is on supporting more complex tax configurations by allowing transactions to reference tax schedules, and by enhancing the `TaxSchedule` model with additional fields and validation logic.

**Modeling and schema enhancements:**

* Added a new `TaxScheduleModel` in `taxSchedule.model.ts`, replacing embedded tax components with references to `Tax` documents, and introduced fields such as `taxInclusive`, `taxExclusive`, `company`, `createdBy`, and `isSuperAdminSchedule`. Includes validation to prevent both inclusive and exclusive flags from being true simultaneously, and sets up compound indexes for uniqueness.
* Exported `TaxScheduleModel` and `TaxScheduleDocument` from the models index for use elsewhere in the codebase.

**Transaction integration:**

* Updated the `TransactionSchema` to include a `taxes` field that references a `TaxSchedule`, enabling transactions to be linked to a specific tax schedule.
* Updated the `Transaction` type definition to include the new `taxes` field, which can be a `mongoose.Types.ObjectId` or a string.